### PR TITLE
Fix elgiganten.se

### DIFF
--- a/clickbait.txt
+++ b/clickbait.txt
@@ -337,5 +337,6 @@ abcnews.go.com###interest-carousel
 nypost.com###circular-widget
 
 ! Whitelist
+elgiganten.se#@#.slick-track
 fanatical.com#@#.slick-track
 nederob.nl#@#.featured-content


### PR DESCRIPTION
`https://www.elgiganten.se/product/datorer-tillbehor/barbar-dator/16454/acer-nitro-5-15-6-barbar-dator-for-gaming-svart`

Missing images of product.