### PR TITLE
Fix filter list duplicates, Taboola network rule, and metadata

### DIFF
--- a/clickbait.txt
+++ b/clickbait.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 
+! Version: 1
 ! Title: Distractions and clickbait filter
-! Last modified: 2018-11-17
+! Last modified: 2026-05-12
 ! Expires: 7 days (update frequency)
 ! Homepage: https://github.com/endolith/clickbait
 ! This URL: https://raw.githubusercontent.com/endolith/clickbait/master/clickbait.txt
@@ -262,7 +262,7 @@ slate.com##.also_in_slate
 slate.com##.rightrailstories
 slate.com##.story-link
 slate.com##.twocolumn-stories
-taboolasyndication.com
+||taboolasyndication.com^
 taboolasyndication.com##*
 theanimalrescuesite.com###recommended
 theguardian.com###promo
@@ -288,13 +288,11 @@ yourtango.com##[class*="view-must-see-video"]
 buzzfeed.com##.thumbstrip
 buzzfeed.com##.clearfix.xs-p2.xs-border-top-none.xs-relative.sidebar-card.card.js-sidebar-content
 buzzfeed.com###mod-related-tag-content-1
-##.ad-before-carousel  
+##.ad-before-carousel
 
 ! huffpost
-##.js-right-rail-trending  
+##.js-right-rail-trending
 ##.yr-trending
-###bottom-most-shared
-###bottom-trending
 ###extra-content
 
 ! thehill.com


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This repository is a single Adblock Plus–style filter list (`clickbait.txt`) plus docs. The following concrete issues were fixed.

## Changes

1. **Duplicate rules** — `###bottom-most-shared` and `###bottom-trending` appeared twice (global block and again under the HuffPost comment). The duplicates in the HuffPost section were removed so the list stays valid and easier to maintain.

2. **Taboola syndication** — The line `taboolasyndication.com` relied on substring matching. It was replaced with `||taboolasyndication.com^`, which is the standard domain-anchored network filter form documented for Adblock Plus and supported by uBlock Origin and related tools.

3. **List metadata** — `! Version:` was empty; it is now set to `1` so issue reports can reference a version. `! Last modified` was updated to match this edit. Trailing spaces were removed from a few filter lines.

## Testing

No automated tests exist in this repo. Validation was done by re-checking the file for duplicate non-comment lines after edits.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32090c06-d5b1-4a12-9d19-597ac901cea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32090c06-d5b1-4a12-9d19-597ac901cea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

