### PR TITLE
Add AGENTS.md and filter-list CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate Adblock filter list
+        run: python3 scripts/validate_filters.py clickbait.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+Adblock Plus filter list (`clickbait.txt`). Not executable code.
+
+## Workflow
+
+1. Branch `cursor/<topic>-6eeb`.
+2. Filter rules must stay valid ABP syntax.
+3. Run local validation before pushing (see below).
+4. Do not merge.
+
+## Local validation
+
+```bash
+python3 scripts/validate_filters.py clickbait.txt
+```
+
+## CI
+
+GitHub Actions runs the same validator on every PR.
+
+## Rules
+
+- No duplicate `! Title` headers or duplicate option lines.
+- Keep `! Homepage` and license lines at top.
+- Test rules against real pages when possible (manual).

--- a/scripts/validate_filters.py
+++ b/scripts/validate_filters.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Validate Adblock Plus filter list syntax (minimal checks)."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def validate(path: Path) -> list[str]:
+    errors: list[str] = []
+    text = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    headers = re.compile(r"^\[(Adblock Plus \d+\.\d+)\]$")
+    seen_headers: set[str] = set()
+
+    for i, line in enumerate(text, 1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("!"):
+            continue
+        if headers.match(stripped):
+            if stripped in seen_headers:
+                errors.append(f"{i}: duplicate header {stripped}")
+            seen_headers.add(stripped)
+            continue
+        if stripped.startswith("@@"):
+            continue
+        if stripped.startswith("/") and stripped.endswith("/"):
+            continue
+        if "##" in stripped or "#@" in stripped or "#?" in stripped:
+            continue
+        if "$" in stripped:
+            continue
+        if stripped.startswith("||") or stripped.startswith("|") or stripped.startswith("."):
+            continue
+        if stripped.startswith("http"):
+            continue
+        if stripped.startswith("#"):
+            continue
+        # Bare domain / hostname blocks (common in older lists)
+        if "." in stripped and " " not in stripped and "/" not in stripped:
+            continue
+        errors.append(f"{i}: unrecognized rule syntax: {stripped[:80]}")
+
+    return errors
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <filter.txt>", file=sys.stderr)
+        return 2
+    path = Path(sys.argv[1])
+    errors = validate(path)
+    if errors:
+        for e in errors:
+            print(e, file=sys.stderr)
+        print(f"{len(errors)} validation error(s)", file=sys.stderr)
+        return 1
+    print(f"OK: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rollout of `templates/json-adblock/` from clone-and-add-forks#7.

- `AGENTS.md` for agent workflow
- `scripts/validate_filters.py` — syntax checks for `clickbait.txt`
- `.github/workflows/ci.yml` runs validator on every PR

No pytest equivalent for filter lists; this is the linter.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

